### PR TITLE
[DevOps-101] Setup mediu de testare: docker, nginx, test-env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,10 @@ services:
       - backend
       - database
       - grafana
-    networks:
+      - backend-testing
+      - frontend-testing
+      - database-testing    
+networks:
       - app-network
   
   backend:
@@ -30,13 +33,37 @@ services:
       - database
     env_file:
       - .env
-    
+  
+   backend-testing:
+    image: ${DOCKER_USER}/backend-testing:latest
+    container_name: backend-testing
+    ports:
+      - "8081:8081"
+    networks:
+      - app-network
+    depends_on:
+      - frontend
+      - database-testing
+    env_file:
+      - .env
+   
   frontend:
     image: ${DOCKER_USER}/frontend:latest
     container_name: frontend
     ports:
       - "3000:3000"
     networks: 
+      - app-network
+
+
+ frontend-testing:
+    image: ${DOCKER_USER}/frontend-testing:latest
+    container_name: frontend-testing
+    ports:
+      - "3001:3001"
+    depends-on:
+      - backend-testing    
+    networks:
       - app-network
 
   database:
@@ -54,6 +81,22 @@ services:
       - postgres_data:/var/lib/postgresql/data
       - ./db:/docker-entrypoint-initdb.d
   
+
+  database-testing:
+    image: postgres:latest
+    container_name: database-testing
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB_TESTING}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    ports:
+      - "5433:5433"
+    networks:
+      - app-network
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./db:/docker-entrypoint-initdb.d
+
   # Monitoring
   grafana:
     image: grafana/grafana-oss

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -9,6 +9,15 @@ http {
   	upstream backend {
   	  server backend:8080;
   	}
+	upstream frontend-testing {
+      server frontend-test:3001;
+    }
+
+	upstream backend-test {
+      server backend-test:8081;
+    }    
+
+
   	upstream prometheus {
       server prometheus:9090;
     }
@@ -43,6 +52,25 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
     }
+		
+	location /testing/api/ {
+      rewrite ^/testing/api(/.*)$ $1 break;
+      proxy_pass http://backend-testing;
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /testing/ {
+      proxy_pass http://frontend-testing;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }	
     
     location /prometheus/ {
     auth_basic "Prometheus Monitoring";


### PR DESCRIPTION
Am configurat un mediu de testare izolat pentru aplicație, conform cerințelor din [DevOps-101]
Fișier `docker-compose.yml` adaptat pentru testare:
- containere separate pentru frontend, backend și baza de date 
- porturi diferite față de mediul de producție
- rețea Docker dedicată

Configurație nouă în `nginx.conf`:
- adăugate upstream-uri pentru containerele de test
- rute dedicate `/testing/` și `/testing/api/`